### PR TITLE
Complete the archive-backport workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,83 @@ Automation tools and Temporal workflows for building debian packages.
 
 ## Dependencies
 
-* juju >= 3.1
-* microk8s in strict confinement (e.g `1.27-strict/stable` channel)
+* Juju >= 3.1
+* MicroK8s in strict confinement (e.g `1.27-strict/stable` channel)
+* Charmed Temporal
+
+## Temporal on MicroK8s
+
+### Configure environment varaibles on MicroK8s host
+Update /etc/environment on MicroK8s host with [proxy environment variables](https://MicroK8s.io/docs/install-proxy) with:
+```
+HTTPS_PROXY=http://squid.internal:3128
+HTTP_PROXY=http://squid.internal:3128
+NO_PROXY=10.0.0.0/8,192.168.0.0/16,127.0.0.1,172.16.0.0/16
+https_proxy=http://squid.internal:3128
+http_proxy=http://squid.internal:3128
+no_proxy=10.0.0.0/8,192.168.0.0/16,127.0.0.1,172.16.0.0/16
+```
+
+### Set up MicroK8s and Temporal
+
+Follow the [temporal tutorial](https://charmhub.io/temporal-k8s/docs/t-introduction) for setting up Temporal on MicroK8s.
+
+After MicroK8s is installed, reconfigure CoreDNS if 8.8.8.8 and 8.8.4.4 DNS servers are not reachable:
+```
+resolvectl
+sudo microk8s disable dns
+sudo microk8s enable dns:10.245.160.2
+```
+The forward DNS servers can also be modified after enabling the addon:
+```
+microk8s kubectl -n kube-system edit configmap/coredns
+```
+Access UI once temporal-ui-k8s is deployed:
+```
+juju status temporal-ui-k8s
+sshuttle -r ubuntu@temporal 10.1.65.0/24 -D
+```
+
+## Backport a Package to the Cloud Archive
+
+Install apt dependencies on worker:
+```
+sudo apt install --yes dput
+```
+
+Create sbuild chroots on worker:
+```
+mk-sbuild jammy
+mk-sbuild focal
+mk-sbuild bionic
+```
+
+Create config file:
+```
+cat << EOF > /etc/artifact-pipeline.conf
+[deb]
+DEBEMAIL="openstack-ubuntu-testing@lists.launchpad.net"
+DEBFULLNAME="Openstack Ubuntu Testing Bot"
+
+[connection]
+host="10.1.65.74"
+port=7233
+EOF
+```
+
+Run worker in a terminal:
+```
+artifact-pipeline.worker-archive-backport --config-file /etc/artifact-pipeline.conf
+```
+
+Run workflow in another terminal:
+```
+artifact-pipeline.workflow-archive-backport --config-file /etc/artifact-pipeline.conf --package python-aodhclient --os-series yoga
+```
+
+## Useful Commands
+Terminate a workflow:
+```
+juju run temporal-admin-k8s/0 tctl args='workflow terminate --workflow_id bom-yoga-workflow'
+```
+

--- a/artifact_pipeline/cmd.py
+++ b/artifact_pipeline/cmd.py
@@ -19,4 +19,4 @@
 
 def main():
     """Place holder function for future use."""
-    print('hello main')
+    print("hello main")

--- a/artifact_pipeline/conf/connection.py
+++ b/artifact_pipeline/conf/connection.py
@@ -20,8 +20,8 @@ from oslo_config import cfg
 
 
 connection_group = cfg.OptGroup(
-    'connection',
-    title='Temporal Server Connection options',
+    "connection",
+    title="Temporal Server Connection options",
     help="""Options under this group are used to define the connection details
             to a Temporal Server.""",
 )
@@ -40,7 +40,7 @@ opts = [
     cfg.StrOpt(
         "namespace",
         default="default",
-        help="Namespace to connect to in the Temporal server."
+        help="Namespace to connect to in the Temporal server.",
     ),
 ]
 

--- a/artifact_pipeline/conf/deb.py
+++ b/artifact_pipeline/conf/deb.py
@@ -20,8 +20,8 @@ from oslo_config import cfg
 
 
 deb_group = cfg.OptGroup(
-    'deb',
-    title='Deb packaging options',
+    "deb",
+    title="Deb packaging options",
     help="""Options under this group are used to define the configuration
             options related to deb packaging.""",
 )
@@ -41,6 +41,11 @@ opts = [
         "DEB_BUILD_OPTIONS",
         default="nostrip",
         help="deb build options",
+    ),
+    cfg.StrOpt(
+        "signing_key",
+        default="",
+        help="The key to use for signing the package.",
     ),
 ]
 

--- a/artifact_pipeline/config.py
+++ b/artifact_pipeline/config.py
@@ -24,8 +24,7 @@ from artifact_pipeline import version
 CONF = artifact_pipeline.conf.CONF
 
 
-def parse_args(argv: List[str],
-               default_config_files: str = None):
+def parse_args(argv: List[str], default_config_files: str = None):
     """Parse command line arguments to load the configuration.
 
     :param argv: list of arguments to parse.
@@ -33,7 +32,9 @@ def parse_args(argv: List[str],
     """
     log.register_options(CONF)
 
-    CONF(argv[1:],
-         project='artifact-pipeline',
-         version=version.version_string(),
-         default_config_files=default_config_files)
+    CONF(
+        argv[1:],
+        project="artifact-pipeline",
+        version=version.version_string(),
+        default_config_files=default_config_files,
+    )

--- a/artifact_pipeline/utils.py
+++ b/artifact_pipeline/utils.py
@@ -1,0 +1,358 @@
+#
+# Copyright (C) 2023 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Utility classes and functions."""
+import asyncio
+from collections import OrderedDict
+import datetime
+from glob import glob
+import jinja2
+import os
+import subprocess
+
+from launchpadlib.launchpad import Launchpad
+from temporalio import activity
+from typing import (
+    Optional,
+)
+
+
+class BuildResult:
+    """Store the build results for a package build."""
+
+    def __init__(
+        self, package: str, version: str = "", status: str = "current"
+    ):
+        self.package = package
+        self.version = version
+        self.status = status
+        self.output = ""
+        self.logfile = ""
+
+    def update_build_result(
+        self, cmd: str, retcode: int, output: str, work_dir: str
+    ):
+        """Update the build results for a package build.
+
+        :param cmd: Most recent command that was executed.
+        :param retcode: Return code from command that was executed.
+        :param output: Output from command that was executed.
+        :param work_dir: Directory where package build artifacts are stored.
+        """
+        if not self.version:
+            pkg_build_dir = glob(f"{work_dir}/{self.package}*")
+            if pkg_build_dir:
+                self.version = pkg_build_dir[0].split(
+                    f"{work_dir}/{self.package}-"
+                )[1]
+
+        if retcode:
+            self.status = "failed"
+
+        formatted = f"+ {' '.join(cmd)}\n{output}+ return code: {retcode}\n"
+        if not self.output:
+            self.output = formatted
+        else:
+            self.output = f"{self.output}\n{formatted}"
+
+        self.logfile = f"{self.package}-{self.version}.build"
+
+    def write_build_result(self, log_dir: str) -> str:
+        """Write the build results output to a file.
+
+        :param log_dir: Directory to store build log file in.
+        """
+        logfile_path = os.path.join(log_dir, self.logfile)
+        with open(logfile_path, "w") as f:
+            f.write(self.output)
+            self.output = ""
+        return logfile_path
+
+
+def _render_file(
+    search_path: str,
+    template_name: str,
+    render_data: dict[str, object],
+    out_file: str,
+):
+    """Render a jinja2 template and data out to a file.
+
+    :param search_path: Directory that contains the templates.
+    :param template_name: Name of template file.
+    :param render_data: Dictionary of data to render.
+    :param out_file: Rendered output file.
+    """
+    loader = jinja2.FileSystemLoader(searchpath=search_path)
+    jenv = jinja2.Environment(loader=loader)
+    template = jenv.get_template(template_name)
+    out_data = template.render(render_data=render_data)
+    with open(out_file, "w", encoding="utf-8") as f:
+        f.write(out_data)
+
+
+def _get_template_path(subpath: str = "") -> str:
+    """Get full path to templates directory or templates subdirectory.
+
+    :param subpath: Optional subdirectory.
+    """
+    return os.path.join(
+        os.path.dirname(os.path.realpath(__file__)), "templates", subpath
+    )
+
+
+def _get_render_dest_path(
+    dest_path: str, dest_subpath: str, render_file: str
+) -> str:
+    """Get the destination path for the render file.
+
+    :param dest_path: Parent path where rendered file will be stored.
+    :param dest_subpath: Subpath where rendered file will be stored.
+    :param render_file: File name of render file.
+    """
+    render_dest = os.path.join(dest_path, dest_subpath)
+    os.makedirs(render_dest, exist_ok=True)
+    return os.path.join(render_dest, render_file)
+
+
+def render_css(dest_path: str):
+    """Render the css files.
+
+    :param dest_path: Parent path where rendered file will be stored.
+    """
+    css_files = ["filter.css", "starter-template.css", "tracker.css"]
+    for css_file in css_files:
+        _render_file(
+            _get_template_path("css"),
+            css_file,
+            {},
+            _get_render_dest_path(dest_path, "css", css_file),
+        )
+
+
+def render_js(dest_path):
+    """Render the js file.
+
+    :param dest_path: Parent path where rendered file will be stored.
+    """
+    js_file = "filter.js"
+    _render_file(
+        _get_template_path("js"),
+        js_file,
+        {},
+        _get_render_dest_path(dest_path, "js", js_file),
+    )
+
+
+def render_html(
+    dest_path: str,
+    os_series: str,
+    os_supported: list[str],
+    build_results: dict[str, object],
+):
+    """Render html file for backport-o-matic report.
+
+    :param dest_path: Parent path where rendered file will be stored.
+    :param os_series: OpenStack series name.
+    :param os_supported: List of supported OpenStack releases for navigation.
+    """
+    render_data = {
+        "os_series": os_series,
+        "timestamp": datetime.datetime.utcnow(),
+        "build_results": build_results,
+    }
+    render_data["os_series"] = "OpenStack {}{}".format(
+        os_series[0].capitalize(), os_series[1:]
+    )
+
+    href_map = OrderedDict()
+    out_index_file = _get_render_dest_path(dest_path, "", "index.html")
+
+    hrefs = [f"{rel}-builds.html" for rel in os_supported]
+    hrefs.sort()
+    for href in hrefs:
+        raw_name = href.split("-", 1)[0]
+        name = "{}{}".format(raw_name[0].capitalize(), raw_name[1:])
+        href_map[name] = {}
+        href_map[name]["href"] = href
+        href_map[name]["status"] = "active"
+    render_data["href_map"] = href_map
+
+    out_builds_file = _get_render_dest_path(
+        dest_path, "", "{}-builds.html".format(os_series)
+    )
+
+    _render_file(
+        _get_template_path(), "builds.html.j2", render_data, out_builds_file
+    )
+    _render_file(
+        _get_template_path(), "index.html.j2", render_data, out_index_file
+    )
+
+
+def subprocess_run(
+    cmd: str, cwd: str = ".", env: dict[str, str] = {}
+) -> tuple[int, str]:
+    """Run command with subprocess.run.
+
+    :param cmd: Command to run.
+    :param cwd: Directory to run command in.
+    :param env: Dictionary of environment variables.
+    """
+    activity.logger.info(f"Running command: {cmd}")
+    result = subprocess.run(
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd=cwd, env=env
+    )
+    activity.logger.info(f"Command output: {result.stdout.decode()}")
+    return result.returncode, result.stdout.decode()
+
+
+async def asyncio_create_subprocess_exec(
+    cmd: str, env: dict[str, str] = {}
+) -> tuple[Optional[int], str]:
+    """Run command with asyncio.create_subprocess_exec.
+
+    :param cmd: Command to run.
+    :param env: Dictionary of environment variables.
+    """
+    activity.logger.info(f"Running command: {cmd}")
+    process = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+        env=env,
+    )
+    stdout, _ = await process.communicate()
+    activity.logger.info(f"Command output: {stdout.decode()}")
+    return (process.returncode, stdout.decode())
+
+
+def query_ca_ppa(
+    ppa_name: str, ubuntu_series: str
+) -> dict[str, dict[str, str]]:
+    """Get mapping of cloud-archive package names to (version, state).
+
+    :param ppa_name: PPA name.
+    :param ubuntu_series: Ubuntu series name.
+    """
+    activity.logger.info("Initializing connection to Lanchpad")
+    conn = {}
+    conn["lp"] = Launchpad.login_anonymously("openstack", "production")
+    conn["ubuntu"] = conn["lp"].distributions["ubuntu"]
+
+    # ppa = conn['lp'].people['ubuntu-cloud-archive'].getPPAByName(name=ppa)
+    ppa = conn["lp"].people["corey.bryant"].getPPAByName(name=ppa_name)
+    distro = ppa.distribution.getSeries(name_or_version=ubuntu_series)
+    package_map = dict[str, dict[str, str]] = {}
+    for pkg in ppa.getPublishedSources(
+        distro_series=distro, status="Published"
+    ):
+        state = "current"
+        if len(pkg.getPublishedBinaries()) == 0:
+            # There are no published binaries, something is wrong with the
+            # build. maybe dep wait, ftbfs.
+            _st = " ".join(list(set([b.buildstate for b in pkg.getBuilds()])))
+            if "Failed to build" in _st:
+                for log in [b.build_log_url for b in pkg.getBuilds()]:
+                    _st += ' <a href="{}">BL</a>'.format(log)
+            state = _st
+
+        package_map[pkg.source_package_name] = {}
+        package_map[pkg.source_package_name]["original_version"] = (
+            pkg.source_package_version,
+            state,
+        )
+    return package_map
+
+
+def os_auth_env(novarc: str) -> dict[str, str]:
+    """Translate openstack credentials file to environment variables.
+
+    :param novarc: OpenStack credentials file name.
+    """
+    env = {}
+    with open(novarc, "r") as f:
+        for line in f.readlines():
+            line = line.replace("export ", "")
+            line = line.replace('"', "")
+            line = line.rstrip()
+            var = line.split("=")[0]
+            val = line.split("=")[1]
+            env[var] = val
+    return env
+
+
+def swift_publish(novarc: str, path: str, header: str = "") -> int:
+    """Publish to swift.
+
+    :param novarc: OpenStack credentials file name.
+    :param path: Path to publish to swift.
+    :param header: Header type to publish with.
+    """
+    assert os.path.isfile(novarc)
+    env = os_auth_env(novarc)
+
+    activity.logger.info("Publishing to swift")
+    cmds = []
+    if header:
+        cmds.append(
+            [
+                "swift",
+                "upload",
+                "reports",
+                "--object-name",
+                "backport-o-matic",
+                "--header",
+                f"{header}",
+                path,
+            ]
+        )
+    else:
+        cmds.append(
+            [
+                "swift",
+                "upload",
+                "reports",
+                "--object-name",
+                "backport-o-matic",
+                path,
+            ]
+        )
+    cmds.append(["swift", "post", "--read-acl", ".r:*,.rlistings", "reports"])
+    for cmd in cmds:
+        retcode, output = subprocess_run(cmd, env=env)
+        if retcode:
+            activity.logger.error("Failure publishing to swift")
+            return retcode
+    return retcode
+
+
+def swift_delete(novarc: str, swift_object: str) -> int:
+    """Delete a swift object.
+
+    :param novarc: OpenStack credentials file name.
+    :param swift_object: Name of swift object to delete.
+    """
+    assert os.path.isfile(novarc)
+    env = os_auth_env(novarc)
+
+    cmd = [
+        "swift",
+        "delete",
+        "reports",
+        os.path.join("backport-o-matic", swift_object),
+    ]
+    retcode, output = subprocess_run(cmd, env=env)
+    return retcode

--- a/artifact_pipeline/version.py
+++ b/artifact_pipeline/version.py
@@ -18,5 +18,5 @@
 import pbr.version
 
 
-version_info = pbr.version.VersionInfo('artifact-pipeline')
+version_info = pbr.version.VersionInfo("artifact-pipeline")
 version_string = version_info.version_string

--- a/artifact_pipeline/workers/hello_world.py
+++ b/artifact_pipeline/workers/hello_world.py
@@ -64,7 +64,7 @@ async def async_main(argv: Optional[List[str]] = None):
         client,
         task_queue=TASK_QUEUE,
         workflows=[SayHello],
-        activities=[say_hello]
+        activities=[say_hello],
     )
     await worker.run()
 

--- a/artifact_pipeline/workflows/hello_world.py
+++ b/artifact_pipeline/workflows/hello_world.py
@@ -64,7 +64,7 @@ def setup_opts(argv: Optional[List[str]]):
     :param argv: list of arguments to parse
     """
     parser = argparse.ArgumentParser()
-    parser.add_argument('--name', required=True, help="Name to say hello to.")
+    parser.add_argument("--name", required=True, help="Name to say hello to.")
     return parser.parse_known_args(argv)
 
 

--- a/artifact_pipeline/zaza/setup.py
+++ b/artifact_pipeline/zaza/setup.py
@@ -27,44 +27,79 @@ from zaza.charm_lifecycle import utils as lifecycle_utils
 def configure_tls():
     """Configure TLS in temporal server deployed by juju."""
     with tempfile.mkdtemp() as tmpdir:
-        server_key = os.path.join(tmpdir, 'server.key')
-        server_csr = os.path.join(tmpdir, 'server.csr')
-        server_crt = os.path.join(tmpdir, 'server.crt')
+        server_key = os.path.join(tmpdir, "server.key")
+        server_csr = os.path.join(tmpdir, "server.csr")
+        server_crt = os.path.join(tmpdir, "server.crt")
         # Generate private key
-        subprocess.check_call(['openssl', 'genrsa', '-out', server_key,
-                               '2048'])
+        subprocess.check_call(
+            ["openssl", "genrsa", "-out", server_key, "2048"]
+        )
         # Generate a certificate signing request
-        subprocess.check_call(['openssl', 'req', '-new', server_key,
-                               '-out', server_csr,
-                               '-subj', '/CN=temporal-k8s'])
+        subprocess.check_call(
+            [
+                "openssl",
+                "req",
+                "-new",
+                server_key,
+                "-out",
+                server_csr,
+                "-subj",
+                "/CN=temporal-k8s",
+            ]
+        )
         # Create self-signed certificate
-        p = subprocess.Popen(['openssl', 'x509', '-req', '-days', '365',
-                              '-in', server_csr, '-signkey', server_key,
-                              '-out', server_crt],
-                             stdin=subprocess.PIPE, text=True)
+        p = subprocess.Popen(
+            [
+                "openssl",
+                "x509",
+                "-req",
+                "-days",
+                "365",
+                "-in",
+                server_csr,
+                "-signkey",
+                server_key,
+                "-out",
+                server_crt,
+            ],
+            stdin=subprocess.PIPE,
+            text=True,
+        )
         p.communicate("subjectAltName=DNS:temporal-k8s")
         p.wait()
         assert p.returncode == 0, str(p)
 
-        subprocess.check_call(['microk8s.kubectl', 'create', 'secret', 'tls',
-                               'temporal-tls', '--cert', server_crt,
-                               '--key', server_key])
         subprocess.check_call(
-            ['microk8s', 'enable',
-             'ingress:default-ssl-certificate=temporal/temporal-tls']
+            [
+                "microk8s.kubectl",
+                "create",
+                "secret",
+                "tls",
+                "temporal-tls",
+                "--cert",
+                server_crt,
+                "--key",
+                server_key,
+            ]
+        )
+        subprocess.check_call(
+            [
+                "microk8s",
+                "enable",
+                "ingress:default-ssl-certificate=temporal/temporal-tls",
+            ]
         )
 
         zaza.model.wait_for_agent_status()
     test_config = lifecycle_utils.get_charm_config(fatal=False)
-    target_deploy_status = test_config.get('target_deploy_status', {})
+    target_deploy_status = test_config.get("target_deploy_status", {})
     try:
         opts = {
-            'workload-status-message-prefix': '',
-            'workload-status': 'active',
+            "workload-status-message-prefix": "",
+            "workload-status": "active",
         }
-        target_deploy_status['temporal-ui-k8s'].update(opts)
+        target_deploy_status["temporal-ui-k8s"].update(opts)
     except KeyError:
         pass
 
-    zaza.model.wait_for_application_states(
-        states=target_deploy_status)
+    zaza.model.wait_for_application_states(states=target_deploy_status)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+Jinja2
+launchpadlib
 temporalio
 oslo.log
 oslo.config

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,6 @@
 from setuptools import setup
 
 setup(
-    setup_requires=['pbr'],
+    setup_requires=["pbr"],
     pbr=True,
 )

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
+black
 flake8
 pydocstyle
 pytest

--- a/tox.ini
+++ b/tox.ini
@@ -36,6 +36,10 @@ commands =
 basepython = python3
 commands = mypy {posargs} artifact_pipeline
 
+[testenv:black]
+basepython = python3
+commands = black {posargs} --line-length 79 artifact_pipeline unit_tests
+
 [testenv:func]
 basepython = python3
 commands = functest-run-suite


### PR DESCRIPTION
The archive-backport workflow is now functional, allowing for backporting an individual package to the cloud archive staging PPA for the specified OpenStack series.

Additionally, this change includes:
* README updates
* Switch to temporal logging
* Addition of utils.py that includes common code
* Add black formatter and formatted code with it
* Fix some mypy errors. There are several more to fix.